### PR TITLE
docs: bumped up version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dsci524_group29_webscraping"
-version = "0.1.0"
+version = "1.1.0"
 description = "A simple Python toolkit for web scraping"
 authors = ["group29"]
 license = "MIT"


### PR DESCRIPTION
I have updated the version in [pyproject.toml] to match the version in GitHub. After this, semantic version should be able to bump up the version of the build. The previous run had a message in the log saying "No release will be made, 0.1.0 has already been released!"