### PR TITLE
docs: improved docstrings for parse_content and save_data (#82)

### DIFF
--- a/src/dsci524_group29_webscraping/parse_content.py
+++ b/src/dsci524_group29_webscraping/parse_content.py
@@ -9,25 +9,31 @@ def parse_content(html_content, selector, selector_type='css'):
     Parses HTML content to extract data based on the provided selector.
 
     Parameters:
-        html_content (str): The raw HTML content.
-        selector (str): The CSS selector or XPath expression to target elements.
-        selector_type (str): The type of selector ('css' or 'xpath'). Case-insensitive.
+        html_content (str): The raw HTML content to be parsed.
+        selector (str): The query to locate elements in the HTML content.
+            - For CSS selectors: Use `.class`, `#id`, or `tagname`.
+            - For XPath: Use expressions like `//tag[@attribute='value']`.
+        selector_type (str, optional): The type of selector to use. Options:
+            - 'css': Uses a CSS selector (e.g., `.item` selects elements with class "item").
+            - 'xpath': Uses an XPath expression (e.g., `//div[@class='item']` selects <div> elements with class "item").
+            Case-insensitive. Default is 'css'.
 
     Returns:
-        list: A list of extracted data elements.
+        list: A list of dictionaries containing extracted data.
+            - Example output: `[{'value': 'alfa'}, {'value': 'bravo'}, {'value': 'charlie'}]`.
 
     Raises:
-        ValueError: If the selector_type is unsupported or parsing fails.
+        ValueError: If the selector_type is unsupported or an error occurs during parsing.
 
     Example:
         # Sample HTML content
-        html_content = '<html><body><div class="item">alfa</div><div class="item">bravo</div> <div class="item">charlie</div> </body> </html>'
+        html_content = '<html><body><div class="item">alfa</div><div class="item">bravo</div><div class="item">charlie</div></body></html>'
 
-        # Using CSS selector
+        # Using a CSS selector
         parse_content(html_content, ".item")  
         # Returns: [{'value': 'alfa'}, {'value': 'bravo'}, {'value': 'charlie'}]
 
-        # Using XPath selector
+        # Using an XPath selector
         parse_content(html_content, "//div[@class='item']", selector_type='xpath')  
         # Returns: [{'value': 'alfa'}, {'value': 'bravo'}, {'value': 'charlie'}]
     """

--- a/src/dsci524_group29_webscraping/save_data.py
+++ b/src/dsci524_group29_webscraping/save_data.py
@@ -8,26 +8,28 @@ import csv
 
 def save_data(data, format='csv', destination='output.csv'):
     """
-    Saves the extracted data into a file in the specified format at the given destination.
+    Saves the extracted data into a file.
 
     Parameters:
         data (list or dict): The data to be saved.
             - For 'csv', it must be a list of dictionaries where each dictionary represents a row.
             - For 'json', it can be either a list or a dictionary.
-        format (str, optional): The file format to save the data. Supported formats are:
-            - 'csv': Saves the data as a CSV file.
-            - 'json': Saves the data as a JSON file.
+        format (str, optional): The format in which to save the data. Options are:
+            - 'csv': Saves the data as a CSV file. Each key in the dictionaries becomes a column header.
+            - 'json': Saves the data as a JSON file. The data is serialized with indentation for readability.
             Default is 'csv'.
-        destination (str, optional): The file path where the data will be saved. 
+        destination (str, optional): The file path to save the data. Can specify:
+            - A file name (e.g., 'output.csv').
+            - A full path (e.g., '/path/to/output.csv').
             Default is 'output.csv'.
 
     Returns:
         str: The absolute path to the saved file.
 
     Raises:
-        ValueError: If the specified format is unsupported or the data structure is incompatible with the format.
+        ValueError: If the format is unsupported or if the data structure is incompatible with the format.
         FileNotFoundError: If the directory specified in the destination path does not exist.
-        Exception: If an unexpected error occurs during the file writing process.
+        Exception: If an unexpected error occurs during the file-writing process.
 
     Examples:
         # Save data as a CSV file
@@ -37,10 +39,10 @@ def save_data(data, format='csv', destination='output.csv'):
         save_data({"name": "Alice", "age": 25}, format='json', destination='data.json')
 
     Notes:
-        - For 'csv', the input data must be a list of dictionaries where each dictionary represents a row in the CSV.
-        - For 'json', the input data can be a dictionary or a list.
-        - If the specified directory in the destination does not exist, a FileNotFoundError will be raised.
+        - The directory specified in the destination path must exist; otherwise, a FileNotFoundError is raised.
+        - For 'csv', the first dictionary in the list determines the column headers.
     """
+    
     # Validate the destination directory
     dir_path = os.path.dirname(destination)
     if dir_path and not os.path.exists(dir_path):


### PR DESCRIPTION
### Changes Made
- **parse_content.py**:
  - Improved the docstring to clarify:
    - The purpose of the `selector` argument, with examples for CSS and XPath selectors.
    - The `selector_type` parameter, its available options (`'css'` or `'xpath'`), and its case-insensitive behavior.
    - The expected output format, with an example output.

- **save_data.py**:
  - Improved the docstring to:
    - Clearly explain how the `destination` parameter works (e.g., specifying a filename or a full path).
    - Provide better detail on the `format` parameter and its supported options (`'csv'` and `'json'`).
    - Include an example for saving data in both CSV and JSON formats.

### Reason for Changes
- Addressed feedback from issue #82.
- Enhanced the readability and usability of the functions' documentation, making it easier for new users to understand.

### Testing
- Verified that both functions work as expected after the documentation changes.
- Ran the test suite using `pytest` to confirm no functionality was altered.

### Linked Issue
Closes #82.